### PR TITLE
ci: use distroless runtime image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,11 @@ jobs:
 
           kubectl wait deployment -n remote-secrets remote-secrets --for condition=Available=True --timeout=180s
 
-          kubectl -n remote-secrets exec $(kubectl get pod -A | grep remote-secrets | awk '{print $2}') -- sh -c 'apk add --no-cache curl && curl http://dockerhost:4566/_floci/init'
+          kubectl -n remote-secrets delete pod/floci-check --ignore-not-found=true
+          kubectl -n remote-secrets run floci-check --image=curlimages/curl:8.11.1 --restart=Never --command -- curl -fsS http://dockerhost:4566/_floci/init
+          kubectl -n remote-secrets wait pod/floci-check --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s
+          kubectl -n remote-secrets logs pod/floci-check
+          kubectl -n remote-secrets delete pod/floci-check --ignore-not-found=true
 
       - name: Sanity check remote secrets
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,7 @@ COPY k8s k8s
 RUN find crd main utils plugins k8s -type f \( -name '*.rs' -o -name 'Cargo.toml' \) -exec touch {} +
 RUN cargo build --release --bin controller
 
-FROM alpine:3.23
-RUN apk --no-cache add ca-certificates
+FROM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /app
-COPY --from=build /app/target/release/controller /app/controller
+COPY --from=build --chown=nonroot:nonroot /app/target/release/controller /app/controller
 CMD ["./controller"]


### PR DESCRIPTION
## Summary
- Switch the final controller image from Alpine to gcr.io/distroless/static-debian12:nonroot
- Copy the controller binary as the nonroot user
- Remove the runtime apk/ca-certificates layer

## Verification
- Reviewed runtime code paths: no app-local file reads/writes or shell execution; Kubernetes in-cluster auth uses mounted service-account files
- Built and smoke-tested the distroless image from the prior clean worktree: binary started successfully and only failed outside Kubernetes due to missing kubeconfig/service-account auth