### PR TITLE
chore(deps): bump cached crate to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,17 +894,14 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.59.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b6f5d101f0f6322c8646a45b7c581a673e476329040d97565815c2461dd0c4"
+checksum = "0fddee1beae7a67a67cfe13f0833b44716f219359ac6c433099e1ae0faaee933"
 dependencies = [
  "ahash",
- "async-trait",
  "cached_proc_macro",
  "cached_proc_macro_types",
- "futures",
  "hashbrown 0.16.1",
- "once_cell",
  "parking_lot",
  "thiserror 2.0.18",
  "tokio",
@@ -913,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.27.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebcf9c75f17a17d55d11afc98e46167d4790a263f428891b8705ab2f793eca3"
+checksum = "21fe1bb11488edf0c44742ed08922597716279435267308ad086b82680320a16"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -925,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro_types"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
+checksum = "26cf465651fa6ad902a2d327ba60c3a6bc61c6a2f4ad70d091cf20dfda0074ef"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ version = "1.0.7"
 [workspace.dependencies]
 anyhow = "1.0"
 async-trait = "0.1.89"
-cached = { version = "0.59.0", features = ["proc_macro", "async"] }
+cached = { version = "1.0.0", features = ["proc_macro", "async"] }
 futures = "0.3"
 json_dotpath = "1.1.0"
 kube = { version = "3.1.0", features = ["runtime", "derive"] }

--- a/plugins/src/aws_cfn.rs
+++ b/plugins/src/aws_cfn.rs
@@ -1,6 +1,6 @@
 use crate::aws_common::{aws_endpoint_url, get_aws_sdk_config, is_test_env};
 use async_trait::async_trait;
-use cached::proc_macro::cached;
+use cached::macros::cached;
 use crd::{Backend, RemoteValue, SecretData};
 
 use anyhow::{anyhow, Result};
@@ -86,7 +86,7 @@ pub fn cloudformation_client(conf: &aws_types::SdkConfig) -> aws_sdk_cloudformat
 
 /// get the data from the secret manager store by name
 /// Will cache the result for 60s
-#[cached(time = 60, result = true)]
+#[cached(ttl = 60, result = true)]
 pub async fn get_cloudformation_outputs(
     stack_name: String,
 ) -> Result<Vec<aws_sdk_cloudformation::types::Output>> {

--- a/plugins/src/aws_secret_manager.rs
+++ b/plugins/src/aws_secret_manager.rs
@@ -1,6 +1,6 @@
 use crate::aws_common::{aws_endpoint_url, get_aws_sdk_config, is_test_env};
 use async_trait::async_trait;
-use cached::proc_macro::cached;
+use cached::macros::cached;
 use crd::{Backend, RemoteValue, SecretData};
 
 use anyhow::Result;
@@ -62,7 +62,7 @@ pub fn secretsmanager_client(conf: &aws_types::SdkConfig) -> aws_sdk_secretsmana
 
 /// get the data from the secret manager store by name
 /// Will cache the result for 60s
-#[cached(time = 60, result = true)]
+#[cached(ttl = 60, result = true)]
 pub async fn get_secretsmanager_parameter(name: String) -> Result<String> {
     let shared_config = get_aws_sdk_config().await?;
     let client = secretsmanager_client(&shared_config);

--- a/plugins/src/aws_ssm.rs
+++ b/plugins/src/aws_ssm.rs
@@ -1,6 +1,6 @@
 use crate::aws_common::{aws_endpoint_url, get_aws_sdk_config, is_test_env};
 use async_trait::async_trait;
-use cached::proc_macro::cached;
+use cached::macros::cached;
 use crd::{Backend, RemoteValue, SecretData};
 
 use anyhow::{anyhow, Result};
@@ -58,7 +58,7 @@ pub fn ssm_client(conf: &aws_types::SdkConfig) -> aws_sdk_ssm::Client {
 
 /// get the data from the ssm parameter store by name
 /// Will cache the result for 60s
-#[cached(time = 60, result = true)]
+#[cached(ttl = 60, result = true)]
 pub async fn get_ssm_parameter(name: String) -> Result<String> {
     let shared_config = get_aws_sdk_config().await?;
     let client = ssm_client(&shared_config);

--- a/plugins/src/pulumi.rs
+++ b/plugins/src/pulumi.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use std::collections::BTreeMap;
 
-use cached::proc_macro::cached;
+use cached::macros::cached;
 use k8s_openapi::ByteString;
 
 use crd::{Backend, RemoteValue, SecretData};
@@ -79,7 +79,7 @@ impl RemoteValue for Pulumi {
     }
 }
 
-#[cached(time = 60, result = true)]
+#[cached(ttl = 60, result = true)]
 pub async fn get_pulumi_outputs(
     path: String,
     pulumi_token: Option<String>,

--- a/plugins/src/vault.rs
+++ b/plugins/src/vault.rs
@@ -2,7 +2,7 @@ use crate::aws_common::is_test_env;
 use async_trait::async_trait;
 use std::collections::BTreeMap;
 
-use cached::proc_macro::cached;
+use cached::macros::cached;
 use k8s_openapi::ByteString;
 
 use crd::{Backend, RemoteValue, SecretData};
@@ -49,7 +49,7 @@ impl RemoteValue for Vault {
     }
 }
 
-#[cached(time = 60, result = true)]
+#[cached(ttl = 60, result = true)]
 pub async fn get_vault_value(path: String) -> Result<String> {
     let client = get_vault_client(path.clone())?;
     let response: serde_json::Value = client.send().await?.json().await?;


### PR DESCRIPTION
## Summary
- bump cached from 0.59.0 to 1.0.0
- update cached macro imports to cached::macros::cached
- rename cached macro ttl argument from time to ttl

## Tests
- cargo test --workspace --all-features --all-targets --no-run
- cargo clippy --workspace --all-targets --all-features -- -D warnings